### PR TITLE
Start implementing control group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ https://apt.llvm.org/
 
 To install these packages on Debian or Ubuntu, try::
 
-  sudo install clang-14 librange-v3-dev librtmidi-dev librtaudio-dev \
+  sudo install clang-15 librange-v3-dev librtmidi-dev librtaudio-dev \
   jackd2 qjackctl
 
 and clone triSYCL somewhere.
@@ -49,10 +49,10 @@ In the top directory of the repository::
 
   mkdir build
   # Configure the project with the triSYCL repository somewhere
-  CXX=clang++-14 cmake .. -DCMAKE_MODULE_PATH=<absolute_path>/triSYCL/cmake \
+  CXX=clang++-15 cmake .. -DCMAKE_MODULE_PATH=<absolute_path>/triSYCL/cmake \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
   # Build the project
-  make --build . --parallel `nproc` --verbose
+  cmake --build . --parallel `nproc` --verbose
 
 Launch ``jackd``, for example with ``qjackctl`` which allows to do the
 right connections between the audio and MIDI flows.

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ https://apt.llvm.org/
 
 To install these packages on Debian or Ubuntu, try::
 
-  sudo install clang-13 librange-v3-dev librtmidi-dev librtaudio-dev \
+  sudo install clang-14 librange-v3-dev librtmidi-dev librtaudio-dev \
   jackd2 qjackctl
 
 and clone triSYCL somewhere.
@@ -49,7 +49,7 @@ In the top directory of the repository::
 
   mkdir build
   # Configure the project with the triSYCL repository somewhere
-  CXX=clang++-13 cmake .. -DCMAKE_MODULE_PATH=<absolute_path>/triSYCL/cmake \
+  CXX=clang++-14 cmake .. -DCMAKE_MODULE_PATH=<absolute_path>/triSYCL/cmake \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   # Build the project
   make --build . --parallel `nproc` --verbose

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ In the top directory of the repository::
   mkdir build
   # Configure the project with the triSYCL repository somewhere
   CXX=clang++-14 cmake .. -DCMAKE_MODULE_PATH=<absolute_path>/triSYCL/cmake \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
   # Build the project
   make --build . --parallel `nproc` --verbose
 

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -61,7 +61,7 @@ class control {
 
     /// A representation of a physical control item in a controller
   /// \todo refactor with concern separation
-  class control_item {
+  class physical_item {
    public:
     enum class type : std::uint8_t { button, knob, slider };
 
@@ -121,7 +121,7 @@ class control {
         listeners;
 
     template <typename... Features>
-    control_item(void*, type t, Features... features) {
+    physical_item(void*, type t, Features... features) {
       // Parse the features
       (
           [&](auto&& f) {
@@ -168,13 +168,13 @@ class control {
         l(value);
     }
 
-    /// Name the control_item
+    /// Name the physical_item
     auto& name(const std::string& new_name) {
       current_name = new_name;
       return *this;
     }
 
-    /// Add an action to the control_item
+    /// Add an action to the physical_item
     template <typename Callable> auto& add_action(Callable&& action) {
       using arg0_t =
           std::tuple_element_t<0, boost::callable_traits::args_t<Callable>>;
@@ -262,14 +262,14 @@ class control {
 
     std::string user_name;
 
-    std::optional<std::reference_wrapper<control_item>> c_i;
+    std::optional<std::reference_wrapper<physical_item>> c_i;
 
     item(const std::string& name, const physical_value_type& a_physical_value)
         : physical_value { a_physical_value }
         , user_name { name } {}
 
     template <typename Group>
-    item(Group* g, control_item& ci, const std::string& name,
+    item(Group* g, physical_item& ci, const std::string& name,
          const physical_value_type& a_physical_value)
         : physical_value { a_physical_value }
         , user_name { name }

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -23,6 +23,7 @@ namespace musycl {
 
 // Break an inclusion cycle
 class user_interface;
+class group;
 
 class control {
  public:
@@ -255,18 +256,14 @@ class control {
     /// The type encapsulating the implementation
     using implementation_t = typename param::shared_ptr_implementation;
 
-    /// Import the constructors
-//    using implementation_t::implementation_t;
-
     // Make the implementation member directly accessible in this class
     using implementation_t::implementation;
 
-    /// Create a param_detail from the arguments
-    param(user_interface& ui, auto&&... args)
-        : implementation_t { new param_detail {
-              ui, std::forward<decltype(args)>(args)... } } {
-      connect(ui, this);
-    }
+    param() = default;
+
+    param(user_interface& ui, const std::string& n,
+          std::optional<midi::channel_type> midi_channel = {})
+        : implementation_t { new param_detail { ui, n, midi_channel } } {}
 
     // Forward everything to the implementation detail
     auto& operator->() const { return implementation; }

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -59,6 +59,7 @@ class control {
     using physical_value<value_type, time>::physical_value;
   };
 
+    /// A representation of a physical control item in a controller
   /// \todo refactor with concern separation
   class control_item {
    public:
@@ -104,6 +105,7 @@ class control {
           , blue_bo { static_cast<std::int8_t>(b) } {}
     };
 
+    // \todo Replace by a variant?
     std::optional<cc> cc_v;
     std::optional<cc_inc> cc_inc_v;
     std::optional<note> note_v;

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -233,7 +233,7 @@ class control {
   };
 
   /** A parameter set shared across various owner instance with a
-      shared pointer façades
+      shared pointer façade
 
       \param[in] ParamDetail is the real implementation of the
       parameter set

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -253,17 +253,17 @@ class control {
     using owner_t = Owner;
 
     /// The type encapsulating the implementation
-    using implementation_t =
-        trisycl::detail::shared_ptr_implementation<param<param_detail, owner_t>,
-                                                   param_detail>;
+    using implementation_t = typename param::shared_ptr_implementation;
 
     /// Import the constructors
-    using implementation_t::implementation_t;
+//    using implementation_t::implementation_t;
 
     // Make the implementation member directly accessible in this class
     using implementation_t::implementation;
 
-    param()
+    param(auto... args)
+//        : implementation_t { new param_detail(
+//              std::forward<decltype(args)>(args)...) } {}
         : implementation_t { new param_detail } {}
 
     // Forward everything to the implementation detail

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -270,7 +270,8 @@ class control {
     auto& operator->() const { return implementation; }
   };
 
-  /// A logical control item to be connected from a group to a physical item
+  /// A logical control \c item to be connected from a \c group to a
+  /// \c physical_item and dispatch from the \c user_interface
   template <typename PhysicalValue> class item {
    public:
     using physical_value_type = PhysicalValue;

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -263,7 +263,9 @@ class control {
 
     param(user_interface& ui, const std::string& n,
           std::optional<midi::channel_type> midi_channel = {})
-        : implementation_t { new param_detail { ui, n, midi_channel } } {}
+        : implementation_t { new param_detail { ui, n, midi_channel } } {
+      std::cerr << "Create " << n << " control::param\n";
+    }
 
     // Forward everything to the implementation detail
     auto& operator->() const { return implementation; }

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -261,10 +261,10 @@ class control {
     // Make the implementation member directly accessible in this class
     using implementation_t::implementation;
 
-    param(auto... args)
-//        : implementation_t { new param_detail(
-//              std::forward<decltype(args)>(args)...) } {}
-        : implementation_t { new param_detail } {}
+    /// Create a param_detail from the arguments
+    param(auto&&... args)
+        : implementation_t { new param_detail {
+              std::forward<decltype(args)>(args)... } } {}
 
     // Forward everything to the implementation detail
     auto& operator->() const { return implementation; }

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -263,9 +263,7 @@ class control {
 
     param(user_interface& ui, const std::string& n,
           std::optional<midi::channel_type> midi_channel = {})
-        : implementation_t { new param_detail { ui, n, midi_channel } } {
-      std::cerr << "Create " << n << " control::param\n";
-    }
+        : implementation_t { new param_detail { ui, n, midi_channel } } {}
 
     // Forward everything to the implementation detail
     auto& operator->() const { return implementation; }

--- a/include/musycl/control.hpp
+++ b/include/musycl/control.hpp
@@ -262,9 +262,11 @@ class control {
     using implementation_t::implementation;
 
     /// Create a param_detail from the arguments
-    param(auto&&... args)
+    param(user_interface& ui, auto&&... args)
         : implementation_t { new param_detail {
-              std::forward<decltype(args)>(args)... } } {}
+              ui, std::forward<decltype(args)>(args)... } } {
+      connect(ui, this);
+    }
 
     // Forward everything to the implementation detail
     auto& operator->() const { return implementation; }

--- a/include/musycl/dco.hpp
+++ b/include/musycl/dco.hpp
@@ -78,7 +78,7 @@ class dco {
     };
   };
 
-  // Shared parameter between all copies of this envelope generator
+  // Shared parameter between all copies of this DCO generator
   using param_t = control::param<param_detail, dco>;
 
   /// Current parameters of the DCO

--- a/include/musycl/dco.hpp
+++ b/include/musycl/dco.hpp
@@ -53,8 +53,7 @@ class dco {
   /// Parameters of the DCO sound
   class param_detail : public group {
    public:
-    /// The user-interface group name for the component
-    std::string group_name { "DCO" };
+    using group::group;
 
     /// Level of the square signal
     control::item<control::level<float>> square_volume {

--- a/include/musycl/envelope.hpp
+++ b/include/musycl/envelope.hpp
@@ -11,8 +11,10 @@
 
 #include <triSYCL/detail/overloaded.hpp>
 
-#include "clock.hpp"
 #include "config.hpp"
+
+#include "clock.hpp"
+#include "group.hpp"
 
 namespace musycl {
 
@@ -45,8 +47,10 @@ class envelope : public clock::follow<envelope> {
 
  public:
   /// Parameters of the envelope shape
-  class param_detail {
+  class param_detail : public group {
    public:
+    using group::group;
+
     /// Attack time, immediate sound by default
     control::item<control::time<float>> attack_time { "Attack", { 0, 10, 0 } };
 
@@ -98,7 +102,7 @@ class envelope : public clock::follow<envelope> {
   envelope() = default;
 
   /// Create an envelope with some specific parameters
-  envelope(param_t p)
+  envelope(const param_t& p)
       : param { p } {}
 
   /** Start the envelope generator from the beginning

--- a/include/musycl/envelope.hpp
+++ b/include/musycl/envelope.hpp
@@ -48,20 +48,18 @@ class envelope : public clock::follow<envelope> {
   class param_detail {
    public:
     /// Attack time, immediate sound by default
-    control::item<control::time<float>> attack_time { 0, "Attack", { 0, 10 } };
+    control::item<control::time<float>> attack_time { "Attack", { 0, 10, 0 } };
 
     /// Decay time, go immediately to sustain phase by default
-    control::item<control::time<float>> decay_time { 0, "Decay", { 0, 10 } };
+    control::item<control::time<float>> decay_time { "Decay", { 0, 10, 0 } };
 
     /// Sustain level, maximum level by default in the sustain phase
-    control::item<control::level<float>> sustain_level { 1,
-                                                         "Sustain",
-                                                         { 0, 1 } };
+    control::item<control::level<float>> sustain_level { "Sustain",
+                                                         { 0, 1, 1 } };
 
     /// Release time, go immediately to off by default
-    control::item<control::time<float>> release_time { 0,
-                                                       "Release",
-                                                       { 0, 10 } };
+    control::item<control::time<float>> release_time { "Release",
+                                                       { 0, 10, 0 } };
   };
 
   // Shared parameter between all copies of this envelope generator
@@ -88,10 +86,10 @@ class envelope : public clock::follow<envelope> {
   */
   friend std::string to_string(const envelope& e) {
     std::ostringstream s;
-    s << "Envelope attack = " << e.param->attack_time.value
-      << ", release = " << e.param->release_time.value
-      << ", sustain = " << e.param->sustain_level.value
-      << ", decay = " << e.param->decay_time.value
+    s << "Envelope attack = " << e.param->attack_time.value()
+      << ", release = " << e.param->release_time.value()
+      << ", sustain = " << e.param->sustain_level.value()
+      << ", decay = " << e.param->decay_time.value()
       << ", current volume = " << e.output;
     return s.str();
   }

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -56,5 +56,10 @@ class group {
   }
 };
 
+// To break a cycle from user_interface.hpp
+bool inline try_dispatch(const group* g, control::physical_item& pi) {
+  return g->try_dispatch(pi);
+};
+
 } // namespace musycl
 #endif // MUSYCL_GROUP_HPP

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -37,7 +37,11 @@ class group {
  public:
   group(musycl::controller::keylab_essential& c, const std::string& n)
       : name { n }
-      , controller { &c } {}
+      , controller { &c } {
+    // Add the group to the user-interface
+    // \todo refactor/clean-up
+    c.add_control_group(*this);
+  }
 
   group() = default;
 

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -34,7 +34,7 @@ class group {
   std::map<control::physical_item*, std::function<void()>> physical_items;
 
   /// A group can also have subgroup to have controllers associated
-  std::vector<group*> subgroups;
+  std::vector<group*> sub_groups;
 
   /// A cache to the already created groups
   // static trisycl::detail::cache<std::string, detail::group> cache;
@@ -62,6 +62,11 @@ class group {
   /// Assign an action to a control item
   void assign(control::physical_item& ci, std::function<void()> f) {
     physical_items.emplace(&ci, f);
+  }
+
+  /// Add a sub-group part of this group
+  void add_as_sub_group_to(group& group_owner) {
+    group_owner.sub_groups.push_back(this);
   }
 
   /** Try to dispatch an action associate to a control item

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -23,6 +23,9 @@ class group {
   /// User-facing name
   std::string name;
 
+  /// A group can be associated to a MIDI channel
+  std::optional<midi::channel_type> channel;
+
   /// Action to dispatch from a control item
   std::map<control::physical_item*, std::function<void()>> physical_items;
 
@@ -35,8 +38,10 @@ class group {
 
   //  controls
  public:
-  group(musycl::controller::keylab_essential& c, const std::string& n)
+  group(musycl::controller::keylab_essential& c, const std::string& n,
+        std::optional<midi::channel_type> midi_channel = {})
       : name { n }
+      , channel { midi_channel }
       , controller { &c } {
     // Add the group to the user-interface
     // \todo refactor/clean-up
@@ -55,9 +60,7 @@ class group {
       \return true if the dispatch was successful or false if there is
       no action for this control item
    */
-  bool try_dispatch(const control::physical_item& ci) const {
-    return false;
-  }
+  bool try_dispatch(const control::physical_item& ci) const { return false; }
 };
 
 // To break a cycle from user_interface.hpp

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -60,7 +60,13 @@ class group {
       \return true if the dispatch was successful or false if there is
       no action for this control item
    */
-  bool try_dispatch(const control::physical_item& ci) const { return false; }
+  bool try_dispatch(control::physical_item& ci) const {
+    auto v = physical_items.find(&ci);
+    if (v == physical_items.end())
+      return false;
+    v->second();
+    return true;
+  }
 };
 
 // To break a cycle from user_interface.hpp

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -1,0 +1,53 @@
+#ifndef MUSYCL_GROUP_HPP
+#define MUSYCL_GROUP_HPP
+
+/** \file Abstractions for group of control items which can be
+    activated on the user interface at some point
+
+*/
+
+#include <functional>
+#include <map>
+#include <string>
+
+//#include "triSYCL/detail/cache.hpp"
+
+#include "musycl/control.hpp"
+#include <musycl/midi/controller/keylab_essential.hpp>
+
+namespace musycl {
+
+/// Represent a set of control which can be activated on the user-interface
+class group {
+
+  /// User-facing name
+  std::string name;
+
+  std::map<control::control_item*, std::function<void()>> control_items;
+
+  /// A cache to the already created groups
+  // static trisycl::detail::cache<std::string, detail::group> cache;
+
+ protected:
+  musycl::controller::keylab_essential* controller;
+
+  //  controls
+ public:
+  group(musycl::controller::keylab_essential& c, const std::string& n)
+      : name { n }
+      , controller { &c } {}
+
+  group() = default;
+
+  void assign(control::control_item& ci, std::function<void()> f) {
+    control_items.emplace(&ci, f);
+  }
+
+  template <typename T> bool try_dispatch(T& ci) const {
+    //    bool try_dispatch(control::control_item& ci) const {
+    return false;
+  }
+};
+
+} // namespace musycl
+#endif // MUSYCL_GROUP_HPP

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -53,7 +53,7 @@ class group {
       , controller { ui.c } {
     // Add the group to the user-interface
     // \todo refactor/clean-up
-    ui.add_layer(*this);
+    ui.add_layer(*this, midi_channel);
   }
 
   group() = default;

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -22,13 +22,14 @@ namespace musycl {
 
 /// Represent a set of control which can be activated on the user-interface
 class group {
-
+ public:
   /// User-facing name
   std::string name;
 
   /// A group can be associated to a MIDI channel \todo unused?
   std::optional<midi::channel_type> channel;
 
+ private:
   /// Action to dispatch from a control item
   std::map<control::physical_item*, std::function<void()>> physical_items;
 

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -15,6 +15,7 @@
 
 #include "musycl/control.hpp"
 #include <musycl/midi/controller/keylab_essential.hpp>
+#include <musycl/user_interface.hpp>
 
 namespace musycl {
 
@@ -38,18 +39,18 @@ class group {
 
  protected:
   /// The \c user_interface associated to the \c group
-  musycl::user_interface* user_interface;
+  user_interface* ui;
 
   /// The \c controller associated to the \c group
-  musycl::controller::keylab_essential* controller;
+  controller::keylab_essential* controller;
 
  public:
-  group(musycl::user_interface& ui, const std::string& n,
+  group(user_interface& ui, const std::string& n,
         std::optional<midi::channel_type> midi_channel = {})
       : name { n }
       , channel { midi_channel }
-      , user_interface { &ui }
-      , controller { static_cast<musycl::controller::keylab_essential*>(get_controller(ui)) } {
+      , ui { &ui }
+      , controller { ui.c } {
     // Add the group to the user-interface
     // \todo refactor/clean-up
     ui.add_layer(*this);

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <vector>
 
 //#include "triSYCL/detail/cache.hpp"
 
@@ -29,23 +30,29 @@ class group {
   /// Action to dispatch from a control item
   std::map<control::physical_item*, std::function<void()>> physical_items;
 
+  /// A group can also have subgroup to have controllers associated
+  std::vector<group*> subgroups;
+
   /// A cache to the already created groups
   // static trisycl::detail::cache<std::string, detail::group> cache;
 
  protected:
-  /// The controller associated to the group
+  /// The \c user_interface associated to the \c group
+  musycl::user_interface* user_interface;
+
+  /// The \c controller associated to the \c group
   musycl::controller::keylab_essential* controller;
 
-  //  controls
  public:
-  group(musycl::controller::keylab_essential& c, const std::string& n,
+  group(musycl::user_interface& ui, const std::string& n,
         std::optional<midi::channel_type> midi_channel = {})
       : name { n }
       , channel { midi_channel }
-      , controller { &c } {
+      , user_interface { &ui }
+      , controller { static_cast<musycl::controller::keylab_essential*>(get_controller(ui)) } {
     // Add the group to the user-interface
     // \todo refactor/clean-up
-    c.add_control_group(*this);
+    ui.add_layer(*this);
   }
 
   group() = default;

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -23,12 +23,14 @@ class group {
   /// User-facing name
   std::string name;
 
+  /// Action to dispatch from a control item
   std::map<control::control_item*, std::function<void()>> control_items;
 
   /// A cache to the already created groups
   // static trisycl::detail::cache<std::string, detail::group> cache;
 
  protected:
+  /// The controller associated to the group
   musycl::controller::keylab_essential* controller;
 
   //  controls
@@ -39,12 +41,17 @@ class group {
 
   group() = default;
 
+  /// Assign an action to a control item
   void assign(control::control_item& ci, std::function<void()> f) {
     control_items.emplace(&ci, f);
   }
 
-  template <typename T> bool try_dispatch(T& ci) const {
-    //    bool try_dispatch(control::control_item& ci) const {
+  /** Try to dispatch an action associate to a control item
+
+      \return true if the dispatch was successful or false if there is
+      no action for this control item
+   */
+  template <typename ControlItem> bool try_dispatch(ControlItem& ci) const {
     return false;
   }
 };

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,7 +26,7 @@ class group {
   /// User-facing name
   std::string name;
 
-  /// A group can be associated to a MIDI channel
+  /// A group can be associated to a MIDI channel \todo unused?
   std::optional<midi::channel_type> channel;
 
   /// Action to dispatch from a control item
@@ -52,8 +53,7 @@ class group {
       , ui { &ui }
       , controller { ui.c } {
     // Add the group to the user-interface
-    // \todo refactor/clean-up
-    ui.add_layer(*this, midi_channel);
+    ui.add_layer(*this);
   }
 
   group() = default;

--- a/include/musycl/group.hpp
+++ b/include/musycl/group.hpp
@@ -24,7 +24,7 @@ class group {
   std::string name;
 
   /// Action to dispatch from a control item
-  std::map<control::control_item*, std::function<void()>> control_items;
+  std::map<control::physical_item*, std::function<void()>> physical_items;
 
   /// A cache to the already created groups
   // static trisycl::detail::cache<std::string, detail::group> cache;
@@ -42,8 +42,8 @@ class group {
   group() = default;
 
   /// Assign an action to a control item
-  void assign(control::control_item& ci, std::function<void()> f) {
-    control_items.emplace(&ci, f);
+  void assign(control::physical_item& ci, std::function<void()> f) {
+    physical_items.emplace(&ci, f);
   }
 
   /** Try to dispatch an action associate to a control item
@@ -51,7 +51,7 @@ class group {
       \return true if the dispatch was successful or false if there is
       no action for this control item
    */
-  template <typename ControlItem> bool try_dispatch(ControlItem& ci) const {
+  bool try_dispatch(const control::physical_item& ci) const {
     return false;
   }
 };

--- a/include/musycl/midi/channel_assignment.hpp
+++ b/include/musycl/midi/channel_assignment.hpp
@@ -2,30 +2,31 @@
 #define MUSYCL_MIDI_CHANNEL_ASSIGNMENT_HPP
 
 /** \file Map MIDI channel to some sound generators
-*/
+ */
 
 #include <map>
 
-#include "musycl/midi.hpp"
+//#include "musycl/midi.hpp"
+#include "musycl/sound_generator.hpp"
 
 namespace musycl::midi {
 
+/** The (MIDI) channel mapping to the sound parameter
+
+    Note that there might be more channels than the 16 real MIDI
+    channels for convenience, for example to have more sounds for
+    arpeggiators
+*/
 class channel_assignment {
-
-  /** The (MIDI) channel mapping to the sound parameter
-
-      Note that there might be more channels than the 16 real MIDI
-      channels for convenience, for example to have more sounds for
-      arpeggiators
-  */
-
+ public:
   std::map<int, musycl::sound_generator::param_t> channels;
 
-  void assign(int channel, musycl::sound_generator::param_t sound {}) {
-    
+  void assign(int channel, const musycl::sound_generator::param_t& sound) {
+    std::cerr << "Assign channel " << channel << std::endl;
+    channels[channel] = sound;
   }
 };
 
-} // namespace musycl
+} // namespace musycl::midi
 
 #endif // MUSYCL_MIDI_CHANNEL_ASSIGNMENT_HPP

--- a/include/musycl/midi/channel_assignment.hpp
+++ b/include/musycl/midi/channel_assignment.hpp
@@ -1,0 +1,31 @@
+#ifndef MUSYCL_MIDI_CHANNEL_ASSIGNMENT_HPP
+#define MUSYCL_MIDI_CHANNEL_ASSIGNMENT_HPP
+
+/** \file Map MIDI channel to some sound generators
+*/
+
+#include <map>
+
+#include "musycl/midi.hpp"
+
+namespace musycl::midi {
+
+class channel_assignment {
+
+  /** The (MIDI) channel mapping to the sound parameter
+
+      Note that there might be more channels than the 16 real MIDI
+      channels for convenience, for example to have more sounds for
+      arpeggiators
+  */
+
+  std::map<int, musycl::sound_generator::param_t> channels;
+
+  void assign(int channel, musycl::sound_generator::param_t sound {}) {
+    
+  }
+};
+
+} // namespace musycl
+
+#endif // MUSYCL_MIDI_CHANNEL_ASSIGNMENT_HPP

--- a/include/musycl/midi/controller/keylab_essential.hpp
+++ b/include/musycl/midi/controller/keylab_essential.hpp
@@ -20,6 +20,7 @@
 
 #include <range/v3/all.hpp>
 
+#include "musycl/control.hpp"
 #include "musycl/midi.hpp"
 #include "musycl/midi/midi_out.hpp"
 

--- a/include/musycl/midi/controller/keylab_essential.hpp
+++ b/include/musycl/midi/controller/keylab_essential.hpp
@@ -274,7 +274,8 @@ class controller {
                                         button_out::pad_2_green } };
 
     /// Start the KeyLab controller
-    keylab_essential() {
+    keylab_essential()
+        : ui { *this } {
       display("Salut les petits amis");
       // button_light_fuzzing();
       // Refresh the LCD display because it is garbled by various information
@@ -298,6 +299,9 @@ class controller {
       midi_out::write(sysex_message);
       return sysex_message;
     }
+
+    /// Return the underlying user interface
+    user_interface& user_interface() { return ui; }
 
     void button_light(std::int8_t button, std::int8_t level) {
       static auto constexpr sysex_button_light = { '\x2', '\0', '\x10' };
@@ -350,11 +354,6 @@ class controller {
       auto light_level = (ct.midi_clock_index < midi::clock_per_quarter / 4) *
                          (32 + 95 * (ct.beat_index == 0));
       button_light((int)button_out::metro, light_level);
-    }
-
-    /// Add a control group to the user-interface
-    void add_control_group(group &g) {
-      ui.add_layer(g);
     }
   };
 };

--- a/include/musycl/midi/controller/keylab_essential.hpp
+++ b/include/musycl/midi/controller/keylab_essential.hpp
@@ -180,94 +180,94 @@ class controller {
     // std::vector<control::physical_item> inputs;
 
     control::physical_item cutoff_pan_1 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x4a }, control::physical_item::cc_inc { 0x10 }
     };
 
     control::physical_item resonance_pan_2 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x47 }, control::physical_item::cc_inc { 0x11 }
     };
 
     control::physical_item lfo_rate_pan_3 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x4c }, control::physical_item::cc_inc { 0x12 }
     };
 
     control::physical_item lfo_amt_pan_4 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x4d }, control::physical_item::cc_inc { 0x13 }
     };
 
     control::physical_item param_1_pan_5 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x5d }, control::physical_item::cc_inc { 0x14 }
     };
 
     control::physical_item param_2_pan_6 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x12 }, control::physical_item::cc_inc { 0x15 }
     };
 
     control::physical_item param_3_pan_7 {
-      this, control::physical_item::type::knob, this,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x13 }, control::physical_item::cc_inc { 0x16 }
     };
 
     control::physical_item param_4_pan_8 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x10 }, control::physical_item::cc_inc { 0x17 }
     };
 
     // The unnamed knob on the top right, non mapped in DAW mode
     control::physical_item top_right_knob_9 {
-      this, control::physical_item::type::knob,
+      ui, control::physical_item::type::knob,
       control::physical_item::cc { 0x11 }
     };
 
-    control::physical_item attack_ch_1 { this,
+    control::physical_item attack_ch_1 { ui,
                                         control::physical_item::type::slider,
                                         control::physical_item::cc { 0x49 } };
 
-    control::physical_item decay_ch_2 { this,
+    control::physical_item decay_ch_2 { ui,
                                        control::physical_item::type::slider,
                                        control::physical_item::cc { 0x4b } };
 
-    control::physical_item sustain_ch_3 { this,
+    control::physical_item sustain_ch_3 { ui,
                                          control::physical_item::type::slider,
                                          control::physical_item::cc { 0x4f } };
 
-    control::physical_item release_ch_4 { this,
+    control::physical_item release_ch_4 { ui,
                                          control::physical_item::type::slider,
                                          control::physical_item::cc { 0x48 } };
 
-    control::physical_item attack_ch_5 { this,
+    control::physical_item attack_ch_5 { ui,
                                         control::physical_item::type::slider,
                                         control::physical_item::cc { 0x50 } };
 
-    control::physical_item decay_ch_6 { this,
+    control::physical_item decay_ch_6 { ui,
                                        control::physical_item::type::slider,
                                        control::physical_item::cc { 0x51 } };
 
-    control::physical_item sustain_ch_7 { this,
+    control::physical_item sustain_ch_7 { ui,
                                          control::physical_item::type::slider,
                                          control::physical_item::cc { 0x52 } };
 
-    control::physical_item release_ch_8 { this,
+    control::physical_item release_ch_8 { ui,
                                          control::physical_item::type::slider,
                                          control::physical_item::cc { 0x53 } };
 
-    control::physical_item play_pause { this,
+    control::physical_item play_pause { ui,
                                        control::physical_item::type::button,
                                        control::physical_item::note { 0x5e } };
 
-    control::physical_item pad_1 = { this, control::physical_item::type::button,
+    control::physical_item pad_1 = { ui, control::physical_item::type::button,
                                     control::physical_item::pad {
                                         0x24, button_out::pad_1_red,
                                         button_out::pad_1_blue,
                                         button_out::pad_1_green } };
 
-    control::physical_item pad_2 = { this, control::physical_item::type::button,
+    control::physical_item pad_2 = { ui, control::physical_item::type::button,
                                     control::physical_item::pad {
                                         0x25, button_out::pad_2_red,
                                         button_out::pad_2_blue,
@@ -350,6 +350,11 @@ class controller {
       auto light_level = (ct.midi_clock_index < midi::clock_per_quarter / 4) *
                          (32 + 95 * (ct.beat_index == 0));
       button_light((int)button_out::metro, light_level);
+    }
+
+    /// Add a control group to the user-interface
+    void add_control_group(group &g) {
+      ui.add_layer(g);
     }
   };
 };

--- a/include/musycl/midi/controller/keylab_essential.hpp
+++ b/include/musycl/midi/controller/keylab_essential.hpp
@@ -23,6 +23,7 @@
 #include "musycl/control.hpp"
 #include "musycl/midi.hpp"
 #include "musycl/midi/midi_out.hpp"
+#include "musycl/user_interface.hpp"
 
 namespace musycl {
 
@@ -147,6 +148,9 @@ class controller {
 
     static auto constexpr sysex_vegas_mode_on = { '\x2', '\0', '\x40', '\x50',
                                                   '\x1' };
+
+    /// The user interface logic
+    user_interface ui;
 
     /** Button light fuzzing
 

--- a/include/musycl/midi/controller/keylab_essential.hpp
+++ b/include/musycl/midi/controller/keylab_essential.hpp
@@ -173,98 +173,98 @@ class controller {
 
    public:
     /// List all the control items
-    // std::vector<control::control_item> inputs;
+    // std::vector<control::physical_item> inputs;
 
-    control::control_item cutoff_pan_1 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x4a }, control::control_item::cc_inc { 0x10 }
+    control::physical_item cutoff_pan_1 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x4a }, control::physical_item::cc_inc { 0x10 }
     };
 
-    control::control_item resonance_pan_2 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x47 }, control::control_item::cc_inc { 0x11 }
+    control::physical_item resonance_pan_2 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x47 }, control::physical_item::cc_inc { 0x11 }
     };
 
-    control::control_item lfo_rate_pan_3 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x4c }, control::control_item::cc_inc { 0x12 }
+    control::physical_item lfo_rate_pan_3 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x4c }, control::physical_item::cc_inc { 0x12 }
     };
 
-    control::control_item lfo_amt_pan_4 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x4d }, control::control_item::cc_inc { 0x13 }
+    control::physical_item lfo_amt_pan_4 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x4d }, control::physical_item::cc_inc { 0x13 }
     };
 
-    control::control_item param_1_pan_5 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x5d }, control::control_item::cc_inc { 0x14 }
+    control::physical_item param_1_pan_5 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x5d }, control::physical_item::cc_inc { 0x14 }
     };
 
-    control::control_item param_2_pan_6 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x12 }, control::control_item::cc_inc { 0x15 }
+    control::physical_item param_2_pan_6 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x12 }, control::physical_item::cc_inc { 0x15 }
     };
 
-    control::control_item param_3_pan_7 {
-      this, control::control_item::type::knob, this,
-      control::control_item::cc { 0x13 }, control::control_item::cc_inc { 0x16 }
+    control::physical_item param_3_pan_7 {
+      this, control::physical_item::type::knob, this,
+      control::physical_item::cc { 0x13 }, control::physical_item::cc_inc { 0x16 }
     };
 
-    control::control_item param_4_pan_8 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x10 }, control::control_item::cc_inc { 0x17 }
+    control::physical_item param_4_pan_8 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x10 }, control::physical_item::cc_inc { 0x17 }
     };
 
     // The unnamed knob on the top right, non mapped in DAW mode
-    control::control_item top_right_knob_9 {
-      this, control::control_item::type::knob,
-      control::control_item::cc { 0x11 }
+    control::physical_item top_right_knob_9 {
+      this, control::physical_item::type::knob,
+      control::physical_item::cc { 0x11 }
     };
 
-    control::control_item attack_ch_1 { this,
-                                        control::control_item::type::slider,
-                                        control::control_item::cc { 0x49 } };
+    control::physical_item attack_ch_1 { this,
+                                        control::physical_item::type::slider,
+                                        control::physical_item::cc { 0x49 } };
 
-    control::control_item decay_ch_2 { this,
-                                       control::control_item::type::slider,
-                                       control::control_item::cc { 0x4b } };
+    control::physical_item decay_ch_2 { this,
+                                       control::physical_item::type::slider,
+                                       control::physical_item::cc { 0x4b } };
 
-    control::control_item sustain_ch_3 { this,
-                                         control::control_item::type::slider,
-                                         control::control_item::cc { 0x4f } };
+    control::physical_item sustain_ch_3 { this,
+                                         control::physical_item::type::slider,
+                                         control::physical_item::cc { 0x4f } };
 
-    control::control_item release_ch_4 { this,
-                                         control::control_item::type::slider,
-                                         control::control_item::cc { 0x48 } };
+    control::physical_item release_ch_4 { this,
+                                         control::physical_item::type::slider,
+                                         control::physical_item::cc { 0x48 } };
 
-    control::control_item attack_ch_5 { this,
-                                        control::control_item::type::slider,
-                                        control::control_item::cc { 0x50 } };
+    control::physical_item attack_ch_5 { this,
+                                        control::physical_item::type::slider,
+                                        control::physical_item::cc { 0x50 } };
 
-    control::control_item decay_ch_6 { this,
-                                       control::control_item::type::slider,
-                                       control::control_item::cc { 0x51 } };
+    control::physical_item decay_ch_6 { this,
+                                       control::physical_item::type::slider,
+                                       control::physical_item::cc { 0x51 } };
 
-    control::control_item sustain_ch_7 { this,
-                                         control::control_item::type::slider,
-                                         control::control_item::cc { 0x52 } };
+    control::physical_item sustain_ch_7 { this,
+                                         control::physical_item::type::slider,
+                                         control::physical_item::cc { 0x52 } };
 
-    control::control_item release_ch_8 { this,
-                                         control::control_item::type::slider,
-                                         control::control_item::cc { 0x53 } };
+    control::physical_item release_ch_8 { this,
+                                         control::physical_item::type::slider,
+                                         control::physical_item::cc { 0x53 } };
 
-    control::control_item play_pause { this,
-                                       control::control_item::type::button,
-                                       control::control_item::note { 0x5e } };
+    control::physical_item play_pause { this,
+                                       control::physical_item::type::button,
+                                       control::physical_item::note { 0x5e } };
 
-    control::control_item pad_1 = { this, control::control_item::type::button,
-                                    control::control_item::pad {
+    control::physical_item pad_1 = { this, control::physical_item::type::button,
+                                    control::physical_item::pad {
                                         0x24, button_out::pad_1_red,
                                         button_out::pad_1_blue,
                                         button_out::pad_1_green } };
 
-    control::control_item pad_2 = { this, control::control_item::type::button,
-                                    control::control_item::pad {
+    control::physical_item pad_2 = { this, control::physical_item::type::button,
+                                    control::physical_item::pad {
                                         0x25, button_out::pad_2_red,
                                         button_out::pad_2_blue,
                                         button_out::pad_2_green } };

--- a/include/musycl/midi/midi_in.hpp
+++ b/include/musycl/midi/midi_in.hpp
@@ -199,8 +199,8 @@ class midi_in {
   template <typename Callable>
   static void add_action(std::int8_t port, const midi::msg_header& header,
                          Callable&& action) {
-    std::cout << "add_action on port " << int { port } << " for" << header
-              << std::endl;
+    std::cout << "midi_in::add_action on port " << int { port } << " for "
+              << header << std::endl;
     midi_actions.emplace(port_msg_header { port, header }, action);
   }
 

--- a/include/musycl/musycl.hpp
+++ b/include/musycl/musycl.hpp
@@ -5,7 +5,6 @@
 
 #include "arpeggiator.hpp"
 #include "audio.hpp"
-#include "channel_assignment.hpp"
 #include "clock.hpp"
 #include "control.hpp"
 #include "dco.hpp"
@@ -13,6 +12,7 @@
 #include "lfo.hpp"
 #include "low_pass_filter.hpp"
 #include "midi.hpp"
+#include "midi/channel_assignment.hpp"
 #include "midi/midi_in.hpp"
 #include "midi/midi_out.hpp"
 #include "modulation_actuator.hpp"

--- a/include/musycl/musycl.hpp
+++ b/include/musycl/musycl.hpp
@@ -20,5 +20,6 @@
 #include "resonance_filter.hpp"
 #include "sound_generator.hpp"
 #include "sustain.hpp"
+#include "user_interface.hpp"
 
 #endif // MUSYCL_MUSYCL_HPP

--- a/include/musycl/musycl.hpp
+++ b/include/musycl/musycl.hpp
@@ -5,6 +5,7 @@
 
 #include "arpeggiator.hpp"
 #include "audio.hpp"
+#include "channel_assignment.hpp"
 #include "clock.hpp"
 #include "control.hpp"
 #include "dco.hpp"

--- a/include/musycl/noise.hpp
+++ b/include/musycl/noise.hpp
@@ -21,8 +21,8 @@ namespace musycl {
 
 /// A digitally controlled oscillator
 class noise {
-  /// 
-  control::group cg { "Noise generator" };
+  ///
+  //  group cg { "Noise generator" };
 
   /// Track if the noise generator is generating a signal or just 0
   bool running = false;
@@ -48,8 +48,7 @@ class noise {
   /// Initial frequency of the note
   float frequency;
 
-public:
-
+ public:
   struct param_t {
     using owner_t = noise;
   };
@@ -68,7 +67,7 @@ public:
     rf_env.param->release_time = 0.01;
   }
 
-/// \todo
+  /// \todo
   noise(const param_t& p) {}
 
   /** Start a note
@@ -84,7 +83,6 @@ public:
     return *this;
   }
 
-
   /** Stop the current note
 
       \param[in] off is the "note off" MIDI event to stop with
@@ -97,38 +95,33 @@ public:
     return *this;
   }
 
-
   /// Return the running status
-  bool is_running() {
-    return running;
-  }
-
+  bool is_running() { return running; }
 
   /// Generate an audio sample
   musycl::audio::frame audio() {
-    lpf_filter.set_cutoff_frequency(frequency*lpf_env.out());
-    res_filter.set_resonance(0.99).set_frequency(2*frequency*rf_env.out());
-   running = lpf_env.is_running() || rf_env.is_running();
+    lpf_filter.set_cutoff_frequency(frequency * lpf_env.out());
+    res_filter.set_resonance(0.99).set_frequency(2 * frequency * rf_env.out());
+    running = lpf_env.is_running() || rf_env.is_running();
 
     musycl::audio::frame f;
     if (running) {
       for (auto& e : f) {
         // A random number between -1 and 1
         auto random =
-          rng()*2./std::numeric_limits<decltype(rng)::value_type>::max() - 1;
+            rng() * 2. / std::numeric_limits<decltype(rng)::value_type>::max() -
+            1;
         // Generate a filtered noise sample with an amplitude directly
         // proportional to the velocity
-        e = lpf_filter.filter(random)*10*res_filter.filter(random)
-          * velocity*volume;
+        e = lpf_filter.filter(random) * 10 * res_filter.filter(random) *
+            velocity * volume;
       }
-    }
-    else
+    } else
       // If the DCO is not running, the output is 0
       ranges::fill(f, 0);
     return f;
   }
-
 };
 
-}
+} // namespace musycl
 #endif // MUSYCL_NOISE_HPP

--- a/include/musycl/noise.hpp
+++ b/include/musycl/noise.hpp
@@ -79,7 +79,7 @@ class noise {
   auto& start(const midi::on& on) {
     velocity = on.velocity_1();
     frequency = midi::frequency(on);
-    running = lpf_env.start().is_running() | rf_env.start().is_running();
+    running = lpf_env.start().is_running() || rf_env.start().is_running();
     return *this;
   }
 

--- a/include/musycl/noise.hpp
+++ b/include/musycl/noise.hpp
@@ -12,6 +12,7 @@
 #include "config.hpp"
 
 #include "audio.hpp"
+#include "group.hpp"
 #include "envelope.hpp"
 #include "low_pass_filter.hpp"
 #include "midi.hpp"

--- a/include/musycl/noise.hpp
+++ b/include/musycl/noise.hpp
@@ -49,9 +49,18 @@ class noise {
   float frequency;
 
  public:
-  struct param_t {
-    using owner_t = noise;
+  /// Parameters of the noise sound
+  class param_detail : public group {
+   public:
+    /// The user-interface group name for the component
+    std::string group_name { "noise" };
   };
+
+  // Shared parameter between all copies of this noise generator
+  using param_t = control::param<param_detail, noise>;
+
+  /// Current parameters of the noise
+  param_t param;
 
   /// Output volume of the note
   float volume { 1 };

--- a/include/musycl/noise.hpp
+++ b/include/musycl/noise.hpp
@@ -53,8 +53,7 @@ class noise {
   /// Parameters of the noise sound
   class param_detail : public group {
    public:
-    /// The user-interface group name for the component
-    std::string group_name { "noise" };
+    using group::group;
   };
 
   // Shared parameter between all copies of this noise generator

--- a/include/musycl/sound_generator/dco_envelope.hpp
+++ b/include/musycl/sound_generator/dco_envelope.hpp
@@ -33,7 +33,7 @@ class dco_envelope
     using group::group;
 
     param_detail(auto&&... args)
-        : dco { std::forward<decltype(args)>(args)... }
+       : dco { std::forward<decltype(args)>(args)... }
         , env { std::forward<decltype(args)>(args)... } {}
 
     /// The DCO parameters

--- a/include/musycl/sound_generator/dco_envelope.hpp
+++ b/include/musycl/sound_generator/dco_envelope.hpp
@@ -33,10 +33,8 @@ class dco_envelope
     param_detail(auto&&... args)
         : dco { std::forward<decltype(args)>(args)... }
         , env { std::forward<decltype(args)>(args)... } {
-            std::cerr << "param_detail dco_enveloppe created\n";
-            std::cerr << "dco name " << dco->name << '\n';
-            std::cerr << "env name " << env->name << '\n';
-            std::cerr << "param_detail dco_enveloppe created\n";
+      dco->add_as_sub_group_to(*this);
+      env->add_as_sub_group_to(*this);
     }
 
     /// The DCO parameters

--- a/include/musycl/sound_generator/dco_envelope.hpp
+++ b/include/musycl/sound_generator/dco_envelope.hpp
@@ -30,11 +30,14 @@ class dco_envelope
   /// All the parameters behind this sound generator
   class param_detail : public group {
    public:
-    using group::group;
-
     param_detail(auto&&... args)
-       : dco { std::forward<decltype(args)>(args)... }
-        , env { std::forward<decltype(args)>(args)... } {}
+        : dco { std::forward<decltype(args)>(args)... }
+        , env { std::forward<decltype(args)>(args)... } {
+            std::cerr << "param_detail dco_enveloppe created\n";
+            std::cerr << "dco name " << dco->name << '\n';
+            std::cerr << "env name " << env->name << '\n';
+            std::cerr << "param_detail dco_enveloppe created\n";
+    }
 
     /// The DCO parameters
     dco::param_t dco;
@@ -50,12 +53,13 @@ class dco_envelope
   param_t param;
 
   /// Control the volume evolution of the sound
-  envelope env { param->env };
+  envelope env;
 
   /// Create a sound from its parameters
   dco_envelope(const param_t& p)
       : dco { p->dco }
-      , param { p } {}
+      , param { p }
+      , env { p->env } {}
 
   /** Start a note
 

--- a/include/musycl/sound_generator/dco_envelope.hpp
+++ b/include/musycl/sound_generator/dco_envelope.hpp
@@ -28,6 +28,8 @@ class dco_envelope
   struct param_t {
     using owner_t = dco_envelope;
 
+    param_t(auto... args) : dco { args...}, env { args...} {}
+
     /// The DCO parameters
     dco::param_t dco;
 

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -14,14 +14,15 @@
 #include <range/v3/all.hpp>
 
 #include "control.hpp"
+#include "group.hpp"
 
 namespace musycl {
 
 class user_interface {
   /** The user interface is made of a stack of active layers
 
-      For a given \c control_item, the current action is the first
-      control_item found in the active layers
+      For a given \c physical_item, the current action is the first
+      physical_item found in the active layers
 
       The top layer (the most visible) is the back of the vector and
       the bottom layer is the front of the vector.
@@ -41,12 +42,12 @@ class user_interface {
   */
   void remove_layer(const group& g) { ranges::remove(active_layers, &g); }
 
-  /** Process an action on a control_item into the current user interface
+  /** Process an action on a physical_item into the current user interface
 
-      \param[in] ci is the control_item to process
+      \param[in] ci is the physical_item to process
   */
-  void dispatch(control::control_item& ci) {
-    // Dispatch the control_item with the first matching dispatcher
+  void dispatch(control::physical_item& ci) {
+    // Dispatch the physical_item with the first matching dispatcher
     // across the layer stack
     for (auto layer : active_layers | ranges::views::reverse)
       if (layer->try_dispatch(ci))

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -49,17 +49,22 @@ class user_interface {
 
   /** Process an action on a physical_item into the current user interface
 
-      \param[in] ci is the physical_item to process
+      \param[in] pi is the physical_item to process
   */
-  void dispatch(control::physical_item& ci) {
+  void dispatch(control::physical_item& pi) {
     // Dispatch the physical_item with the first matching dispatcher
     // across the layer stack
     for (auto layer : active_layers | ranges::views::reverse)
-      if (try_dispatch(layer, ci))
+      if (try_dispatch(layer, pi))
         break;
   }
 };
 
+/// Break an inclusion cycle in control.hpp
+void inline user_interface_dispach_physical_item(user_interface& ui,
+                                                 control::physical_item& pi) {
+  ui.dispatch(pi);
+}
 } // namespace musycl
 
 #endif // MUSYCL_USER_INTERFACE_HPP

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -35,10 +35,19 @@ class user_interface {
   std::vector<const group*> active_layers;
 
  public:
+
+  /// The \c controller associated to the \c user_interface
+  void* controller;
+
   /** Add a layer on top of the user interface
 
       \param[in] g is the layer to add
   */
+
+  user_interface(auto& controller)
+    : controller { &controller } {}
+
+  /// Add a control group to the user-interface
   void add_layer(const group& g) { active_layers.emplace_back(&g); }
 
   /** Remove a layer from the user interface
@@ -65,6 +74,11 @@ void inline user_interface_dispach_physical_item(user_interface& ui,
                                                  control::physical_item& pi) {
   ui.dispatch(pi);
 }
+
+  /// Break an inclusion cycle in control.hpp
+  static auto get_controller(user_interface& ui) {
+    return ui.controller;
+  }
 } // namespace musycl
 
 #endif // MUSYCL_USER_INTERFACE_HPP

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -7,7 +7,6 @@
 */
 
 #include <algorithm>
-#include <functional>
 //#include <ranges>
 #include <vector>
 

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -1,0 +1,59 @@
+#ifndef MUSYCL_USER_INTERFACE_HPP
+#define MUSYCL_USER_INTERFACE_HPP
+
+/** \file
+
+    Represent the user interface of the synthesizer
+*/
+
+#include <algorithm>
+#include <functional>
+//#include <ranges>
+#include <vector>
+
+#include <range/v3/all.hpp>
+
+#include "control.hpp"
+
+namespace musycl {
+
+class user_interface {
+  /** The user interface is made of a stack of active layers
+
+      For a given \c control_item, the current action is the first
+      control_item found in the active layers
+
+      The top layer (the most visible) is the back of the vector and
+      the bottom layer is the front of the vector.
+  */
+  std::vector<const group*> active_layers;
+
+ public:
+  /** Add a layer on top of the user interface
+
+      \param[in] g is the layer to add
+  */
+  void add_layer(const group& g) { active_layers.emplace_back(&g); }
+
+  /** Remove a layer from the user interface
+
+      \param[in] g is the layer to remove
+  */
+  void remove_layer(const group& g) { ranges::remove(active_layers, &g); }
+
+  /** Process an action on a control_item into the current user interface
+
+      \param[in] ci is the control_item to process
+  */
+  void dispatch(control::control_item& ci) {
+    // Dispatch the control_item with the first matching dispatcher
+    // across the layer stack
+    for (auto layer : active_layers | ranges::views::reverse)
+      if (layer->try_dispatch(ci))
+        break;
+  }
+};
+
+} // namespace musycl
+
+#endif // MUSYCL_USER_INTERFACE_HPP

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -14,9 +14,14 @@
 #include <range/v3/all.hpp>
 
 #include "control.hpp"
-#include "group.hpp"
+// Forward declare for now
+//#include "group.hpp"
 
 namespace musycl {
+
+// Forward declare for now
+class group;
+bool try_dispatch(const group*, control::physical_item&);
 
 class user_interface {
   /** The user interface is made of a stack of active layers
@@ -50,7 +55,7 @@ class user_interface {
     // Dispatch the physical_item with the first matching dispatcher
     // across the layer stack
     for (auto layer : active_layers | ranges::views::reverse)
-      if (layer->try_dispatch(ci))
+      if (try_dispatch(layer, ci))
         break;
   }
 };

--- a/include/musycl/user_interface.hpp
+++ b/include/musycl/user_interface.hpp
@@ -14,6 +14,7 @@
 #include <range/v3/all.hpp>
 
 #include "control.hpp"
+
 // Forward declare for now
 //#include "group.hpp"
 
@@ -22,6 +23,9 @@ namespace musycl {
 // Forward declare for now
 class group;
 bool try_dispatch(const group*, control::physical_item&);
+namespace controller {
+  class keylab_essential;
+}
 
 class user_interface {
   /** The user interface is made of a stack of active layers
@@ -37,15 +41,7 @@ class user_interface {
  public:
 
   /// The \c controller associated to the \c user_interface
-  void* controller;
-
-  /** Add a layer on top of the user interface
-
-      \param[in] g is the layer to add
-  */
-
-  user_interface(auto& controller)
-    : controller { &controller } {}
+  controller::keylab_essential* c;
 
   /// Add a control group to the user-interface
   void add_layer(const group& g) { active_layers.emplace_back(&g); }
@@ -67,6 +63,10 @@ class user_interface {
       if (try_dispatch(layer, pi))
         break;
   }
+
+  void set_controller(controller::keylab_essential& cont) {
+    c = &cont;
+  }
 };
 
 /// Break an inclusion cycle in control.hpp
@@ -75,10 +75,6 @@ void inline user_interface_dispach_physical_item(user_interface& ui,
   ui.dispatch(pi);
 }
 
-  /// Break an inclusion cycle in control.hpp
-  static auto get_controller(user_interface& ui) {
-    return ui.controller;
-  }
 } // namespace musycl
 
 #endif // MUSYCL_USER_INTERFACE_HPP

--- a/src/musycl_synth.cpp
+++ b/src/musycl_synth.cpp
@@ -47,18 +47,11 @@ int main() {
   musycl::midi_out midi_out;
   midi_out.open("muSYCL", "output", RtMidi::UNIX_JACK);
 
-  musycl::user_interface ui;
+  midi::channel_assignment ca;
+  musycl::user_interface ui { ca };
 
   // Assume an Arturia KeyLab essential as a MIDI controller
   musycl::controller::keylab_essential controller { ui };
-
-  /** The (MIDI) channel mapping to the sound parameter
-
-      Note that there might be more channels than the 16 real MIDI
-      channels for convenience, for example to have more sounds for
-      arpeggiators
-  */
-  std::map<int, musycl::sound_generator::param_t> channel_assign;
 
   // The sound generators producing the music, 1 per running note & MIDI channel
   std::map<musycl::midi::note_base_header, musycl::sound_generator> sounds;

--- a/src/musycl_synth.cpp
+++ b/src/musycl_synth.cpp
@@ -174,17 +174,24 @@ int main() {
   controller.param_4_pan_8.name("Delay line ratio")
     .set_variable(delay_line_ratio);
 
-  musycl::dco_envelope::param_t dcoe1;
+  auto ui = controller.user_interface();
+  musycl::dco_envelope::param_t dcoe1 { ui, 0 };
   dcoe1.env->attack_time = 0.1;
   dcoe1.env->decay_time = 0.4;
   dcoe1.env->sustain_level = 0.3;
   dcoe1.env->release_time = 0.5;
 
-  musycl::dco_envelope::param_t dcoe2;
+  musycl::dco_envelope::param_t dcoe2 { ui, 1 };
   dcoe2.env->decay_time = .1;
   dcoe2.env->sustain_level = .1;
 
-  musycl::dco::param_t dco3;
+  musycl::dco::param_t dco3 { ui, 2 };
+
+  musycl::noise::param_t noise { ui, 3 };
+
+  musycl::dco::param_t dco5 { ui, 4 };
+
+  musycl::dco::param_t dco6 { ui, 5 };
 
   // MIDI channel mapping
   musycl::sound_generator::param_t channel_assign[] {

--- a/src/musycl_synth.cpp
+++ b/src/musycl_synth.cpp
@@ -291,47 +291,49 @@ int main() {
   controller.param_4_pan_8.name("Delay line ratio")
       .set_variable(delay_line_ratio);
 
-  musycl::dco_envelope::param_t dcoe1 { ui, 0 };
-  dcoe1.env->attack_time = 0.1;
-  dcoe1.env->decay_time = 0.4;
-  dcoe1.env->sustain_level = 0.3;
-  dcoe1.env->release_time = 0.5;
+  musycl::dco_envelope::param_t dcoe1 { ui, "DCO envelope 1", 0 };
+  dcoe1->env->attack_time = 0.1;
+  dcoe1->env->decay_time = 0.4;
+  dcoe1->env->sustain_level = 0.3;
+  dcoe1->env->release_time = 0.5;
 
-  musycl::dco_envelope::param_t dcoe2 { ui, 1 };
-  dcoe2.env->decay_time = .1;
-  dcoe2.env->sustain_level = .1;
+  musycl::dco_envelope::param_t dcoe2 { ui, "DCO envelope 1", 1 };
+  dcoe2->env->decay_time = .1;
+  dcoe2->env->sustain_level = .1;
 
   // Triangle wave
-  musycl::dco::param_t dco3 { ui, 2 };
+  musycl::dco::param_t dco3 { ui, "Triangle wave", 2 };
   dco3->square_volume = 0;
   dco3->triangle_volume = 1;
 
-  musycl::noise::param_t noise { ui, 3 };
+  musycl::noise::param_t noise { ui, "Noise", 3 };
 
-  musycl::dco::param_t dco5 { ui, 4 };
+  musycl::dco::param_t dco5 { ui, "Plain DCO", 4 };
 
   // Triangle wave with fast decay
-  musycl::dco_envelope::param_t triangle6_fast_decay { ui, 5 };
-  triangle6_fast_decay.dco->square_volume = 0;
-  triangle6_fast_decay.dco->triangle_volume = 1;
-  triangle6_fast_decay.env->decay_time = .1;
-  triangle6_fast_decay.env->sustain_level = .1;
+  musycl::dco_envelope::param_t triangle6_fast_decay { ui,
+                                                       "Triangle fast decay",
+                                                       5 };
+  triangle6_fast_decay->dco->square_volume = 0;
+  triangle6_fast_decay->dco->triangle_volume = 1;
+  triangle6_fast_decay->env->decay_time = .1;
+  triangle6_fast_decay->env->sustain_level = .1;
 
   // Control the DCO 1 & 3 parameters
-  controller.attack_ch_1.connect(dcoe1.dco->square_volume);
+  controller.attack_ch_1.connect(dcoe1->dco->square_volume);
   controller.attack_ch_1.connect(dco3->square_volume);
-  controller.decay_ch_2.connect(dcoe1.dco->triangle_volume);
+  controller.decay_ch_2.connect(dcoe1->dco->triangle_volume);
   controller.decay_ch_2.connect(dco3->triangle_volume);
-  controller.sustain_ch_3.connect(dcoe1.dco->triangle_ratio);
+  controller.sustain_ch_3.connect(dcoe1->dco->triangle_ratio);
   controller.sustain_ch_3.connect(dco3->triangle_ratio);
-  controller.release_ch_4.connect(dcoe1.dco->triangle_fall_ratio);
+  controller.release_ch_4.connect(dcoe1->dco->triangle_fall_ratio);
   controller.release_ch_4.connect(dco3->triangle_fall_ratio);
 
   // Control the envelope of CH1 with Attack/CH5 to Release/CH8
-  controller.attack_ch_5.connect(dcoe1.env->attack_time);
-  controller.decay_ch_6.connect(dcoe1.env->decay_time);
-  controller.sustain_ch_7.connect(dcoe1.env->sustain_level);
-  controller.release_ch_8.connect(dcoe1.env->release_time);
+  controller.attack_ch_5.connect(dcoe1->env->attack_time);
+  controller.decay_ch_6.connect(dcoe1->env->decay_time);
+  controller.sustain_ch_7.connect(dcoe1->env->sustain_level);
+  controller.release_ch_8.connect(dcoe1->env->release_time);
 
   // Connect the sustain pedal to its MIDI event
   musycl::midi_in::cc_action<64>(

--- a/src/musycl_synth.cpp
+++ b/src/musycl_synth.cpp
@@ -47,8 +47,11 @@ int main() {
   musycl::midi_out midi_out;
   midi_out.open("muSYCL", "output", RtMidi::UNIX_JACK);
 
-  midi::channel_assignment ca;
-  musycl::user_interface ui { ca };
+  // The (channel mapping to the sound parameter
+  musycl::midi::channel_assignment channel_assignment;
+
+  // The user interface abstraction
+  musycl::user_interface ui;
 
   // Assume an Arturia KeyLab essential as a MIDI controller
   musycl::controller::keylab_essential controller { ui };
@@ -285,28 +288,34 @@ int main() {
       .set_variable(delay_line_ratio);
 
   musycl::dco_envelope::param_t dcoe1 { ui, "DCO envelope 1", 0 };
+  channel_assignment.assign(0, dcoe1);
   dcoe1->env->attack_time = 0.1;
   dcoe1->env->decay_time = 0.4;
   dcoe1->env->sustain_level = 0.3;
   dcoe1->env->release_time = 0.5;
 
   musycl::dco_envelope::param_t dcoe2 { ui, "DCO envelope 1", 1 };
+  channel_assignment.assign(1, dcoe2);
   dcoe2->env->decay_time = .1;
   dcoe2->env->sustain_level = .1;
 
   // Triangle wave
   musycl::dco::param_t dco3 { ui, "Triangle wave", 2 };
+  channel_assignment.assign(2, dco3);
   dco3->square_volume = 0;
   dco3->triangle_volume = 1;
 
   musycl::noise::param_t noise { ui, "Noise", 3 };
+  channel_assignment.assign(3, noise);
 
   musycl::dco::param_t dco5 { ui, "Plain DCO", 4 };
+  channel_assignment.assign(4, dco5);
 
   // Triangle wave with fast decay
   musycl::dco_envelope::param_t triangle6_fast_decay { ui,
                                                        "Triangle fast decay",
                                                        5 };
+  channel_assignment.assign(5, triangle6_fast_decay);
   triangle6_fast_decay->dco->square_volume = 0;
   triangle6_fast_decay->dco->triangle_volume = 1;
   triangle6_fast_decay->env->decay_time = .1;
@@ -358,8 +367,8 @@ int main() {
                      [&](musycl::midi::on& on) {
                        ts::pipe::cout::stream()
                            << "MIDI on " << (int)on.note << std::endl;
-                       if (auto sp = channel_assign.find(on.channel);
-                           sp != channel_assign.end())
+                       if (auto sp = channel_assignment.channels.find(on.channel);
+                           sp != channel_assignment.channels.end())
                          sounds
                              .insert_or_assign(
                                  on.base_header(),


### PR DESCRIPTION
Move control items from the Keylab MIDI controller into its own
control file.
Implement a group stub.
Put more matter into physical value types.
Introduce the concept of user interface to schedule some day various
control groups.